### PR TITLE
add new benchmarks for blue, pointer2 and pycycle3

### DIFF
--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -8,10 +8,8 @@
 
     "dependencies": [
         "python=2.7",
-        "numpy",
+        "numpy=1.12",
         "scipy",
-        "networkx",
-        "sqlitedict",
         "mpi4py",
         "git+https://bitbucket.org/petsc/petsc4py@3.7.0",
         "~/dev/pyoptsparse"

--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -13,8 +13,7 @@
         "networkx",
         "sqlitedict",
         "mpi4py",
-        "git+https://bitbucket.org/petsc/petsc@v3.5",
-        "git+https://bitbucket.org/petsc/petsc4py@3.5",
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0",
         "~/dev/pyoptsparse"
     ]
 }

--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -1,6 +1,8 @@
 {
     "repository": "git@github.com:OpenMDAO/CADRE",
 
+    "skip": 1,
+
     "triggers": [
         "git@github.com:openmdao/OpenMDAO",
         "git@github.com:openmdao/MBI"

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -353,9 +353,9 @@ def activate_env(env_name, dependencies, local_repos):
     # triggers are installed from a local copy of the repo via 'setup.py install'
     for local_repo in local_repos:
         with repo(local_repo):
-            code, out, err = execute_cmd("pip install -e .")
+            code, out, err = execute_cmd("pip install -q -e .")
             if (code != 0):
-                code, out, err = execute_cmd("python setup.py install")
+                code, out, err = execute_cmd("python setup.py install -q")
             if (code != 0):
                 raise RuntimeError("Failed to install", local_repo, "to", env_name, code, out, err)
 

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -307,7 +307,6 @@ def activate_env(env_name, dependencies, local_repos):
         "git",          # for cloning git repos
         "mercurial",    # for cloning hg repos
         "swig",         # for building dependencies
-        "cython",       # for building dependencies
         "psutil",       # for testflo benchmarking
         "nomkl",        # TODO: experiment with this
         "matplotlib",   # for plotting results

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -382,7 +382,7 @@ def activate_env(env_name, dependencies, local_repos):
             with cd(os.path.expanduser(dependency)):
                 code, out, err = execute_cmd("python setup.py -q install")
             if (code != 0):
-                raise RuntimeError("Failed to install", local_repo, "to", env_name, code, out, err)
+                raise RuntimeError("Failed to install", dependency, "to", env_name, code, out, err)
         # python, numpy and scipy are installed when the env is created
         elif (not dependency.startswith("python=") and
               not dependency.startswith("numpy") and not dependency.startswith("scipy")):

--- a/runner/blue.json
+++ b/runner/blue.json
@@ -2,15 +2,15 @@
     "repository": "git@github.com:openmdao/blue",
 
     "triggers": [
-        "~/dev/pyoptsparse"
     ],
 
     "dependencies": [
-        "python=3",
+        "python=2",
         "numpy",
         "scipy",
         "mpi4py",
-        "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0",
+        "~/dev/pyoptsparse"
     ]
 }
 

--- a/runner/blue.json
+++ b/runner/blue.json
@@ -1,0 +1,16 @@
+{
+    "repository": "git@github.com:openmdao/blue",
+
+    "triggers": [
+        "~/dev/pyoptsparse"
+    ],
+
+    "dependencies": [
+        "python=3",
+        "numpy",
+        "scipy",
+        "mpi4py",
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
+    ]
+}
+

--- a/runner/mission.json
+++ b/runner/mission.json
@@ -9,6 +9,8 @@
 
     "dependencies": [
         "python=2.7",
+        "numpy",
+        "scipy",
         "mpi4py",
         "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
     ]

--- a/runner/mission.json
+++ b/runner/mission.json
@@ -1,6 +1,8 @@
 {
     "repository": "git@github.com:OpenMDAO/mission-allocation",
 
+    "skip": 1,
+
     "triggers": [
         "git@github.com:openmdao/OpenMDAO",
         "git@github.com:openmdao/MBI",

--- a/runner/mission.json
+++ b/runner/mission.json
@@ -5,8 +5,7 @@
 
     "triggers": [
         "git@github.com:openmdao/OpenMDAO",
-        "git@github.com:openmdao/MBI",
-        "~/dev/pyoptsparse"
+        "git@github.com:openmdao/MBI"
     ],
 
     "dependencies": [
@@ -14,7 +13,8 @@
         "numpy",
         "scipy",
         "mpi4py",
-        "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0",
+        "~/dev/pyoptsparse"
     ]
 }
 

--- a/runner/mission.json
+++ b/runner/mission.json
@@ -9,13 +9,8 @@
 
     "dependencies": [
         "python=2.7",
-        "numpy",
-        "scipy",
-        "networkx",
-        "sqlitedict",
         "mpi4py",
-        "git+https://bitbucket.org/petsc/petsc@v3.5",
-        "git+https://bitbucket.org/petsc/petsc4py@3.5"
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
     ]
 }
 

--- a/runner/mission.json
+++ b/runner/mission.json
@@ -4,7 +4,7 @@
     "triggers": [
         "git@github.com:openmdao/OpenMDAO",
         "git@github.com:openmdao/MBI",
-        "https://bitbucket.org/mdolab/pyoptsparse"
+        "~/dev/pyoptsparse"
     ],
 
     "dependencies": [

--- a/runner/oas.json
+++ b/runner/oas.json
@@ -1,0 +1,12 @@
+{
+    "repository": "git@github.com:johnjasa/OpenAeroStruct",
+    "branch": "blue",
+
+    "dependencies": [
+        "python=2.7",
+        "numpy",
+        "scipy",
+        "git+https://github.com/openmdao/blue"
+    ]
+}
+

--- a/runner/oas.json
+++ b/runner/oas.json
@@ -2,6 +2,8 @@
     "repository": "git@github.com:johnjasa/OpenAeroStruct",
     "branch": "blue",
 
+    "skip": 1,
+
     "dependencies": [
         "python=2.7",
         "numpy",

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -6,8 +6,7 @@
         "numpy",
         "scipy",
         "mpi4py",
-        "git+https://bitbucket.org/petsc/petsc@v3.5",
-        "git+https://bitbucket.org/petsc/petsc4py@3.5",
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0",
         "~/dev/pyoptsparse"
     ]
 }

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -1,6 +1,8 @@
 {
     "repository": "git@github.com:openmdao/OpenMDAO",
 
+    "skip": 1,
+
     "dependencies": [
         "python=2.7",
         "numpy",

--- a/runner/pointer.json
+++ b/runner/pointer.json
@@ -1,6 +1,8 @@
 {
     "repository": "git@github.com:openmdao/pointer",
 
+    "skip": 1,
+
     "triggers": [
         "git@github.com:openmdao/OpenMDAO",
         "git@github.com:openmdao/MBI"

--- a/runner/pointer.json
+++ b/runner/pointer.json
@@ -10,8 +10,6 @@
         "python=2.7",
         "numpy",
         "scipy",
-        "networkx",
-        "sqlitedict",
         "nose"
     ]
 }

--- a/runner/pointer2.json
+++ b/runner/pointer2.json
@@ -1,20 +1,17 @@
 {
     "repository": "git@github.com:openmdao/pointer2",
 
-    "env": {
-        "PYTHONPATH": "$PYTHONPATH:$HOME/pyoptsparse/build/lib.linux-x86_64-2.7"
-    },
-
     "triggers": [
         "git@github.com:openmdao/blue",
         "git@github.com:SMTorg/smt"
     ],
 
     "dependencies": [
-        "python=2.7",
-        "numpy=1.12",
+        "python=2",
+        "numpy",
         "scipy",
-        "mpi4py"
+        "mpi4py",
+        "~/dev/pyoptsparse"
     ]
 }
 

--- a/runner/pointer2.json
+++ b/runner/pointer2.json
@@ -7,7 +7,7 @@
     ],
 
     "dependencies": [
-        "python=2",
+        "python=3",
         "numpy",
         "scipy",
         "mpi4py",

--- a/runner/pointer2.json
+++ b/runner/pointer2.json
@@ -1,0 +1,21 @@
+{
+    "repository": "git@github.com:openmdao/pointer2",
+
+    "env": {
+        "PYTHONPATH": "$PYTHONPATH:$HOME/pyoptsparse/build/lib.linux-x86_64-2.7"
+    },
+
+    "triggers": [
+        "git@github.com:openmdao/blue",
+        "git@github.com:SMTorg/smt"
+    ],
+
+    "dependencies": [
+        "python=2.7",
+        "numpy=1.12",
+        "scipy",
+        "mpi4py"
+    ]
+}
+
+

--- a/runner/pycycle3.json
+++ b/runner/pycycle3.json
@@ -1,0 +1,16 @@
+{
+    "repository": "git@github.com:openmdao/pycycle3",
+
+    "triggers": [
+        "~/dev/pyoptsparse"
+    ],
+
+    "dependencies": [
+        "python=3",
+        "numpy",
+        "scipy",
+        "mpi4py",
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
+    ]
+}
+

--- a/runner/pycycle3.json
+++ b/runner/pycycle3.json
@@ -2,15 +2,17 @@
     "repository": "git@github.com:openmdao/pycycle3",
 
     "triggers": [
-        "~/dev/pyoptsparse"
+        "git@github.com:openmdao/blue",
+        "git@github.com:SMTorg/smt"
     ],
 
     "dependencies": [
-        "python=3",
+        "python=2",
         "numpy",
         "scipy",
         "mpi4py",
-        "git+https://bitbucket.org/petsc/petsc4py@3.7.0"
+        "git+https://bitbucket.org/petsc/petsc4py@3.7.0",
+        "~/dev/pyoptsparse"
     ]
 }
 

--- a/runner/pycycle3.json
+++ b/runner/pycycle3.json
@@ -6,7 +6,7 @@
     ],
 
     "dependencies": [
-        "python=2",
+        "python=3",
         "numpy",
         "scipy",
         "mpi4py",

--- a/runner/pycycle3.json
+++ b/runner/pycycle3.json
@@ -2,8 +2,7 @@
     "repository": "git@github.com:openmdao/pycycle3",
 
     "triggers": [
-        "git@github.com:openmdao/blue",
-        "git@github.com:SMTorg/smt"
+        "git@github.com:openmdao/blue"
     ],
 
     "dependencies": [


### PR DESCRIPTION
"skip" old benchmarks
don't clone when installing local dependencies (e.g. pyoptsparse)
enable project specific env vars
fix bug that was installing project twice by adding it to triggers
misc cleanup

