### PR TITLE
Revert "require py3.8 for pyoptsparse"

### DIFF
--- a/runner/openmdao-pyoptsparse.json
+++ b/runner/openmdao-pyoptsparse.json
@@ -10,7 +10,7 @@
     ],
 
     "conda": [
-        "python>=3.8",
+        "python=3",
         "numpy",
         "scipy"
     ],


### PR DESCRIPTION
Reverts OpenMDAO/benchmark#94