### PR TITLE
updates

### DIFF
--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -28,7 +28,7 @@
     ],
 
     "postinstall": [
-        "pip install ~/dev/build_pyoptsparse",
+        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -14,10 +14,8 @@
         "python=3",
         "gfortran=12",
         "numpy",
-        "scipy"
-    ],
-
-    "anaconda": [
+        "scipy",
+        "six"
     ],
 
     "conda-forge": [
@@ -30,10 +28,8 @@
     ],
 
     "postinstall": [
-        "~/dev/build_pyoptsparse/build_pyoptsparse.sh -p `pwd` -s ~/dev/snopt7/src",
-        "export IPOPT_INC=`pwd`/include/coin-or",
-        "export IPOPT_LIB=`pwd`/lib",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib"
+        "pip install ~/dev/build_pyoptsparse",
+        "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -28,7 +28,7 @@
     ],
 
     "postinstall": [
-        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
+        "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/LEAPS2.json
+++ b/runner/LEAPS2.json
@@ -23,7 +23,7 @@
     ],
 
     "postinstall": [
-        "pip install ~/dev/build_pyoptsparse",
+        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/LEAPS2.json
+++ b/runner/LEAPS2.json
@@ -17,20 +17,14 @@
         "scipy"
     ],
 
-    "conda-forge": [
-        "pyoptsparse"
-    ],
-
     "dependencies": [
         "pyxdsm",
         "matplotlib"
     ],
 
     "postinstall": [
-        "~/dev/build_pyoptsparse/build_pyoptsparse.sh -p `pwd` -s ~/dev/snopt7/src",
-        "export IPOPT_INC=`pwd`/include/coin-or",
-        "export IPOPT_LIB=`pwd`/lib",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib"
+        "pip install ~/dev/build_pyoptsparse",
+        "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/LEAPS2.json
+++ b/runner/LEAPS2.json
@@ -23,7 +23,7 @@
     ],
 
     "postinstall": [
-        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
+        "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/TACS.json
+++ b/runner/TACS.json
@@ -12,7 +12,8 @@
 
     "conda": [
         "sysroot_linux-64=2.17",
-        "gxx_linux-64=9.3.0",
+        "gxx_linux-64=8.5.0",
+        "zlib",
         "python=3",
         "numpy",
         "scipy"

--- a/runner/TACS.json
+++ b/runner/TACS.json
@@ -24,6 +24,7 @@
     ],
 
     "install": [
+        "pip install 'pip<22.1'",
         "export OPTIONAL=default",
         "export INTERFACE=interface",
         "export EXAMPLES=default",

--- a/runner/TACS.json
+++ b/runner/TACS.json
@@ -6,14 +6,18 @@
         "git@github.com:OpenMDAO/OpenMDAO"
     ],
 
-    "preinstall": [
-        "unset USE_PROC_FILES"
+    "script_prefix": [
+        "#!/bin/bash",
+        "set -e",
+        "",
+        "module purge",
+        "module load miniforge/4.10.3",
+        "eval \"$(conda shell.bash hook)\""
     ],
 
     "conda": [
         "sysroot_linux-64=2.17",
-        "gxx_linux-64=8.5.0",
-        "zlib",
+        "gxx_linux-64=9.3.0",
         "python=3",
         "numpy",
         "scipy"
@@ -24,8 +28,13 @@
         "petsc4py"
     ],
 
+    "dependencies": [
+        "'pip<22.1'",
+        "testflo"
+    ],
+
     "install": [
-        "pip install 'pip<22.1'",
+        "conda list",
         "export OPTIONAL=default",
         "export INTERFACE=interface",
         "export EXAMPLES=default",

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -413,10 +413,8 @@ class RunScript(object):
 
         self.script = script = []
 
-        # script.append("set -v")
-        # script.append("set -e")
-
-        for line in conf.get("script_prefix"):
+        script_prefix = project.get("script_prefix", conf.get("script_prefix"))
+        for line in script_prefix:
             script.append(line)
 
         script.append("\nRUN_NAME=%s" % run_name)

--- a/runner/dymos.json
+++ b/runner/dymos.json
@@ -29,7 +29,7 @@
     "extras": "[all]",
 
     "postinstall": [
-        "pip install ~/dev/build_pyoptsparse",
+        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/dymos.json
+++ b/runner/dymos.json
@@ -29,7 +29,7 @@
     "extras": "[all]",
 
     "postinstall": [
-        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
+        "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/dymos.json
+++ b/runner/dymos.json
@@ -17,9 +17,6 @@
         "scipy"
     ],
 
-    "anaconda": [
-    ],
-
     "conda-forge": [
         "mpi4py",
         "petsc4py"
@@ -32,10 +29,8 @@
     "extras": "[all]",
 
     "postinstall": [
-        "~/dev/build_pyoptsparse/build_pyoptsparse.sh -p `pwd` -s ~/dev/snopt7/src",
-        "export IPOPT_INC=`pwd`/include/coin-or",
-        "export IPOPT_LIB=`pwd`/lib",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib"
+        "pip install ~/dev/build_pyoptsparse",
+        "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/mach_test.sh
+++ b/runner/mach_test.sh
@@ -20,10 +20,9 @@ eval "$(conda shell.bash hook)"
 
 module load openmpi/4.1.3/gnu/8.5.0
 export OMPI_MCA_rmaps_base_oversubscribe=1
-mpicc --version
 
 #
-# need a python environment with mpi4py and mkdocs 
+# need a python environment with mpi4py and mkdocs
 #
 conda deactivate
 conda deactivate
@@ -42,6 +41,7 @@ if ! conda env list | grep mach_test; then
 else
   conda activate mach_test
 fi
+mpicc --version
 
 echo "#########################"
 echo "Build ESP"
@@ -132,7 +132,7 @@ cmake .. \\
   -DMETIS_DIR="/lib64/" \\
   -DHYPRE_DIR="/hx/software/apps/hypre/2.20.0/" \\
   -DPUMI_DIR="\$WD/core/build/install" \\
-  -DCMAKE_POSITION_INDEPENDENT_CODE=YES 
+  -DCMAKE_POSITION_INDEPENDENT_CODE=YES
 EOF
 source config_mfem.sh
 make -j

--- a/runner/openmdao-pyoptsparse.json
+++ b/runner/openmdao-pyoptsparse.json
@@ -33,8 +33,8 @@
     "postinstall": [
         "export LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/mdolab/pyoptsparse/releases/latest`",
         "export LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,\"/tag/\"); print a[2]}'`",
-        "pip install ~/dev/build_pyoptsparse",
-        "build_pyoptsparse -s ~/dev/snopt7/src"
+        "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
+        "build_pyoptsparse -b $LATEST_VER -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/openmdao-pyoptsparse.json
+++ b/runner/openmdao-pyoptsparse.json
@@ -33,11 +33,8 @@
     "postinstall": [
         "export LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/mdolab/pyoptsparse/releases/latest`",
         "export LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,\"/tag/\"); print a[2]}'`",
-        "echo ~/dev/build_pyoptsparse/build_pyoptsparse.sh -b $LATEST_VER -p `pwd` -s ~/dev/snopt7/src",
-        "~/dev/build_pyoptsparse/build_pyoptsparse.sh -b $LATEST_VER -p `pwd` -s ~/dev/snopt7/src",
-        "export IPOPT_INC=`pwd`/include/coin-or",
-        "export IPOPT_LIB=`pwd`/lib",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib"
+        "pip install ~/dev/build_pyoptsparse",
+        "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -30,7 +30,7 @@
     "extras": "[all]",
 
     "postinstall": [
-        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
+        "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -30,10 +30,8 @@
     "extras": "[all]",
 
     "postinstall": [
-        "~/dev/build_pyoptsparse/build_pyoptsparse.sh -p `pwd` -s ~/dev/snopt7/src",
-        "export IPOPT_INC=`pwd`/include/coin-or",
-        "export IPOPT_LIB=`pwd`/lib",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib"
+        "pip install ~/dev/build_pyoptsparse",
+        "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -30,7 +30,7 @@
     "extras": "[all]",
 
     "postinstall": [
-        "pip install ~/dev/build_pyoptsparse",
+        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 

--- a/runner/pycycle.json
+++ b/runner/pycycle.json
@@ -16,9 +16,6 @@
         "scipy"
     ],
 
-    "anaconda": [
-    ],
-
     "conda-forge": [
         "mpi4py",
         "petsc4py"
@@ -29,11 +26,11 @@
     ],
 
     "postinstall": [
-        "~/dev/build_pyoptsparse/build_pyoptsparse.sh -p `pwd` -s ~/dev/snopt7/src",
-        "export IPOPT_INC=`pwd`/include/coin-or",
-        "export IPOPT_LIB=`pwd`/lib",
-        "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib"
+        "pip install ~/dev/build_pyoptsparse",
+        "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
+
+    "benchmark_timout": 600,
 
     "notify": [
         "!subteam^S01PJ2C9GPN"

--- a/runner/pycycle.json
+++ b/runner/pycycle.json
@@ -26,11 +26,9 @@
     ],
 
     "postinstall": [
-        "pip install ~/dev/build_pyoptsparse",
+        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
-
-    "benchmark_timout": 600,
 
     "notify": [
         "!subteam^S01PJ2C9GPN"

--- a/runner/pycycle.json
+++ b/runner/pycycle.json
@@ -26,7 +26,7 @@
     ],
 
     "postinstall": [
-        "pip install git+https://github.com/tadkollar/build_pyoptsparse@overhaul",
+        "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
         "build_pyoptsparse -s ~/dev/snopt7/src"
     ],
 


### PR DESCRIPTION
- update various projects to use new pip-installable `build_pyoptsparse` script
- add `six` dependency for `CADRE`
- allow `script_prefix` to be specified for project, falling back to benchmark config
- revert to installing pip dependencies last
- add # of failed tests/benchmarks to log/slack message
- revert to using `hypre` module for `mach`
- change `slurm_benchmarks.sh` script to use options and support a timeout argument
- add configurable `test_timeout` and `benchmark_timeout`
