### PR TITLE
pin python 3.10 for mach

### DIFF
--- a/runner/mach_test.sh
+++ b/runner/mach_test.sh
@@ -34,7 +34,7 @@ if conda env list | grep mach_test; then
     conda env remove -n mach_test
 fi
 if ! conda env list | grep mach_test; then
-  conda create --yes -n mach_test python=3 gxx_linux-64=8.4.0 sysroot_linux-64=2.17 cmake cython swig
+  conda create --yes -n mach_test python=3.10 gxx_linux-64=8.4.0 sysroot_linux-64=2.17 cmake cython swig
   conda activate mach_test
   conda install --yes -c conda-forge mpi4py petsc4py
   pip install mkdocs


### PR DESCRIPTION
the __mach_test__ script is failing due to some complication with the Python 3.11 release:
```
Traceback (most recent call last):
  File "/mdao/u/swryan/.conda/envs/mach_test/bin/pip", line 6, in <module>
    from pip._internal.cli.main import main
ModuleNotFoundError: No module named 'pip'
```
Pin Python 3.10 for now