### PR TITLE
stick with Python 3.10

### DIFF
--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -11,7 +11,7 @@
     ],
 
     "conda": [
-        "python=3",
+        "python=3.10",
         "gfortran=12",
         "numpy",
         "scipy",

--- a/runner/LEAPS2.json
+++ b/runner/LEAPS2.json
@@ -11,7 +11,7 @@
     ],
 
     "conda": [
-        "python",
+        "python=3.10",
         "gfortran=12",
         "numpy",
         "scipy"

--- a/runner/TACS.json
+++ b/runner/TACS.json
@@ -18,7 +18,7 @@
     "conda": [
         "sysroot_linux-64=2.17",
         "gxx_linux-64=9.3.0",
-        "python=3",
+        "python=3.10",
         "numpy",
         "scipy"
     ],

--- a/runner/dymos.json
+++ b/runner/dymos.json
@@ -11,7 +11,7 @@
     ],
 
     "conda": [
-        "python=3",
+        "python=3.10",
         "gfortran=12",
         "numpy",
         "scipy",

--- a/runner/openmdao-pyoptsparse.json
+++ b/runner/openmdao-pyoptsparse.json
@@ -10,7 +10,7 @@
     ],
 
     "conda": [
-        "python=3",
+        "python=3.10",
         "gfortran=12",
         "numpy",
         "scipy",

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -9,7 +9,7 @@
     ],
 
     "conda": [
-        "python=3",
+        "python=3.10",
         "gfortran=12",
         "numpy",
         "scipy",


### PR DESCRIPTION

The release of Python 3.11 broke some dependencies.  Stick with Python 3.10 for now.