### PR TITLE
updates to accomodate numpy 1.24

### DIFF
--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -13,7 +13,7 @@
     "conda": [
         "python=3.10",
         "gfortran=12",
-        "numpy",
+        "numpy=1.23",
         "scipy",
         "six"
     ],

--- a/runner/dymos.json
+++ b/runner/dymos.json
@@ -31,7 +31,7 @@
 
     "postinstall": [
         "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
-        "build_pyoptsparse -s ~/dev/snopt7/src"
+        "build_pyoptsparse -b v2.9.2 -s ~/dev/snopt7/src"
     ],
 
     "notify": [

--- a/runner/openmdao.json
+++ b/runner/openmdao.json
@@ -32,7 +32,7 @@
 
     "postinstall": [
         "pip install git+https://github.com/OpenMDAO/build_pyoptsparse",
-        "build_pyoptsparse -s ~/dev/snopt7/src"
+        "build_pyoptsparse -b v2.9.2 -s ~/dev/snopt7/src"
     ],
 
     "notify": [


### PR DESCRIPTION
- update openmdao & dymos to use pyOS 2.9.2, which has the fix for NumPy 1.24
- keep CADRE on NumPy 1.23 until it is updated for NumPy 1.24 compatibility