### PR TITLE
unset USE_PROC_FILES

### DIFF
--- a/runner/TACS.json
+++ b/runner/TACS.json
@@ -59,7 +59,12 @@
         "echo ==========================",
         "echo pip install",
         "echo ==========================",
-        "pip install ."
+        "pip install .",
+        "echo ==========================",
+        "echo USE_PROC_FILES seems to be",
+        "echo a problem with TACS>3.2.1 ",
+        "echo ==========================",
+        "unset USE_PROC_FILES"
     ],
 
     "notify": [

--- a/runner/slurm_benchmarks.sh
+++ b/runner/slurm_benchmarks.sh
@@ -62,6 +62,7 @@ cat << EOM >$RUN_NAME.sh
 
 export OMPI_MCA_mpi_warn_on_fork=0
 ulimit -s 10240
+unset USE_PROC_FILES
 
 testflo -n 1 -bvs -o $OUT_FILE -d $CSV_FILE --timeout=$TIMEOUT
 EOM


### PR DESCRIPTION
TACS benchmarks started failing due to a problem with stdout pointer being set to /dev/null:
```    use_proc_files()
  File "/home/swryan/miniconda3/envs/TACS/lib/python3.10/site-packages/openmdao/utils/mpi.py", line 57, in use_proc_files
    _redirect_streams(ofile.fileno())
  File "/home/swryan/miniconda3/envs/TACS/lib/python3.10/site-packages/openmdao/utils/mpi.py", line 29, in _redirect_streams
    original_stdout_fd = sys.stdout.fileno()
AttributeError: 'DevNull' object has no attribute 'fileno'
```