### PR TITLE
Customize Aviary script to run additional unit tests

### DIFF
--- a/runner/Aviary.json
+++ b/runner/Aviary.json
@@ -28,8 +28,19 @@
 
     "postinstall": [
         "cd aviary/xdsm",
-        "for fn in `ls *.py`; do python $fn; done",
+        "python run_all.py",
         "cd ../.."
+    ],
+
+    "test_cmd": [
+        "FAIL1=0",
+        "testflo --timeout=120 --show_skipped -o $RUN_NAME.log || FAIL1=$?",
+        "FAIL2=0",
+        "testflo --timeout=1500 --show_skipped -o $RUN_NAME.bench.log --testmatch=bench_test* || FAIL2=$?",
+        "cat $RUN_NAME.bench.log >> $RUN_NAME.log",
+        "if [ $FAIL1 || $FAIL2 ]; then",
+        "  exit 1",
+        "fi"
     ],
 
     "notify": [

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -546,7 +546,11 @@ class RunScript(object):
         if unit_tests:
             script.append("\n## Run unit tests")
             if "test_cmd" in project:
-                script.append(project.get("test_cmd"))
+                test_cmd = project.get("test_cmd")
+                if isinstance(test_cmd, list):
+                    script.append("\n".join(test_cmd))
+                else:
+                    script.append(test_cmd)
             else:
                 script.append("testflo -n 1 --timeout=%d --show_skipped -o $RUN_NAME.log" %
                               project.get("test_timeout", conf.get("test_timeout", 120)))
@@ -1432,7 +1436,7 @@ class BenchmarkRunner(object):
                                 os.remove(csv_file)
                         else:
                             # no benchmarks, just record the commits that passed testing
-                            self.slack.post_message("%s unit testing was successful but no benchmarks were found." % trigger_msg)
+                            self.slack.post_message("%s Unit testing was successful but no benchmarks were found." % trigger_msg)
                             timestamp = time.time()
                             db.update_commits(current_commits, timestamp)
                     else:


### PR DESCRIPTION
Run the `bench_test` unit tests (with a 25 minute timeout) as well as the standard unit tests, combine the results into a single test results file.

May resolve https://github.com/OpenMDAO/Aviary/issues/227, depending on whether the change to `testflo` is desired or not.