### PR TITLE
pin metis=5.1.0 for TACS

### DIFF
--- a/runner/TACS.json
+++ b/runner/TACS.json
@@ -25,6 +25,7 @@
 
     "conda-forge": [
         "mpi4py",
+        "metis=5.1.0",
         "petsc4py"
     ],
 


### PR DESCRIPTION
Metis 5.1.1 causes a number of test failures like the following:
```(mpi) /mdao/u/swryan/benchmark/runner/repos/TACS/tacs/tests/integration_tests/test_shell_plate_rbe2_pytacs.py:ProblemTest.test_solve  ... FAIL (00:00:0.00, 0 MB)
[0]PETSC ERROR: ------------------------------------------------------------------------
[0]PETSC ERROR: Caught signal number 11 SEGV: Segmentation Violation, probably memory access out of range
[0]PETSC ERROR: Try option -start_in_debugger or -on_error_attach_debugger
[0]PETSC ERROR: or see https://petsc.org/release/faq/#valgrind and https://petsc.org/release/faq/
[0]PETSC ERROR: configure using --with-debugging=yes, recompile, link, and run 
[0]PETSC ERROR: to get more information on the crash.
[0]PETSC ERROR: Run with -malloc_debug to check if memory corruption is causing the crash.
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 59.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```
Pin to Metis 5.1.0 until notified otherwise by @timryanb 