### PR TITLE
Sync Aviary dependencies etc with workflow

### DIFF
--- a/runner/Aviary.json
+++ b/runner/Aviary.json
@@ -8,7 +8,7 @@
     ],
 
     "conda": [
-        "python=3.10",
+        "python=3.12",
         "numpy",
         "scipy",
         "matplotlib",
@@ -22,14 +22,11 @@
     ],
 
     "dependencies": [
-        "testflo",
+        "matplotlib",
+        "pandas",
+        "panel",
+        "hvplot",
         "pyxdsm"
-    ],
-
-    "postinstall": [
-        "cd aviary/xdsm",
-        "python run_all.py",
-        "cd ../.."
     ],
 
     "test_cmd": [


### PR DESCRIPTION
- updated dependencies for Aviary benchmarks with list from workflow
- removed the processing of XDSM files post-install
- changed to use Python 3.12 (workflow still baselines 3.10 but tests latest (3.x)
