### PR TITLE
pin setuptools for MBI in CADRE.json

### DIFF
--- a/runner/CADRE.json
+++ b/runner/CADRE.json
@@ -14,6 +14,7 @@
         "python=3.10",
         "gfortran=12",
         "numpy=1.23",
+        "'setuptools<65'",
         "scipy",
         "six"
     ],


### PR DESCRIPTION
MBI installation requires older version of setuptools.

CADRE is broken for recent releases of OpenMDAO, per https://github.com/OpenMDAO/OpenMDAO/issues/3447, but this will allow the tests to run (and fail).