### PR TITLE
Skip testing of failed commits when running GitHub workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -98,6 +98,7 @@ jobs:
           wget -q openmdao.org/benchmark/data/$PROJECT_NAME.db  || echo "No data found for $PROJECT_NAME"
           cd ..
           ls -l data
+          wget -q openmdao.org/benchmark/data/$PROJECT_NAME.fail  || echo "No fail file found for $PROJECT_NAME"
 
           echo "============================================================="
           echo "Fetch SNOPT source if needed"

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -1441,6 +1441,13 @@ class BenchmarkRunner(object):
                                     self.slack.post_message(msg % trigger_msg)
                         else:
                             write_json(fail_file, current_commits)
+                            try:
+                                upload(fail_file, conf["data_dir"])
+                            except KeyError:
+                                pass  # remote backup not configured
+                            except:
+                                logging.error("ERROR attempting to upload fail file")
+                                logging.error(traceback.format_exc())
 
 
                     if good_commits:

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -1441,13 +1441,6 @@ class BenchmarkRunner(object):
                                     self.slack.post_message(msg % trigger_msg)
                         else:
                             write_json(fail_file, current_commits)
-                            try:
-                                upload(fail_file, conf["data_dir"])
-                            except KeyError:
-                                pass  # remote backup not configured
-                            except:
-                                logging.error("ERROR attempting to upload fail file")
-                                logging.error(traceback.format_exc())
 
 
                     if good_commits:
@@ -1458,6 +1451,15 @@ class BenchmarkRunner(object):
                         else:
                             # back up and transfer database
                             db.backup()
+
+                    if os.path.exists(fail_file):
+                        try:
+                            upload([fail_file], conf["data_dir"])
+                        except KeyError:
+                            pass  # remote backup not configured
+                        except:
+                            logging.error("ERROR attempting to upload fail file")
+                            logging.error(traceback.format_exc())
         finally:
             # close the log file for this run
             close_log_file()

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -1454,7 +1454,7 @@ class BenchmarkRunner(object):
 
                     if os.path.exists(fail_file):
                         try:
-                            upload([fail_file], conf["data_dir"])
+                            upload([fail_file], "/".join([conf["data"]["upload"], conf["data_dir"]])
                         except KeyError:
                             pass  # remote backup not configured
                         except:

--- a/runner/benchmark.py
+++ b/runner/benchmark.py
@@ -1454,7 +1454,7 @@ class BenchmarkRunner(object):
 
                     if os.path.exists(fail_file):
                         try:
-                            upload([fail_file], "/".join([conf["data"]["upload"], conf["data_dir"]])
+                            upload([fail_file], "/".join([conf["data"]["upload"], conf["data_dir"]]))
                         except KeyError:
                             pass  # remote backup not configured
                         except:


### PR DESCRIPTION
When a project fails testing, the set of commits that triggered the failure are written to a JSON file named _{project_name}_.fail.

If the script is run again against the same set of commits found in the fail file, it will not run the tests again and simply report that that set of commits has already failed testing.

This functionality was not supported on the GitHub workflow because the fail file was not preserved between runs.

This change is to save and restore the fail file similarly to the database file, so that the same set of failed commits will not run (and fail) every night.
